### PR TITLE
removed type instability

### DIFF
--- a/src/ParallelKMeans.jl
+++ b/src/ParallelKMeans.jl
@@ -9,5 +9,6 @@ include("lloyd.jl")
 include("light_elkan.jl")
 
 export kmeans
+export Lloyd, LightElkan
 
 end # module

--- a/src/kmeans.jl
+++ b/src/kmeans.jl
@@ -167,9 +167,9 @@ function update_centroids!(centroids, containers, alg, design_matrix, n_threads)
 
     if n_threads == 1
         r = axes(design_matrix, 2)
-        J = chunk_update_centroids!(centroids, containers, alg, design_matrix, r, 0)
+        J = chunk_update_centroids!(centroids, containers, alg, design_matrix, r, 1)
 
-        centroids .= containers.new_centroids ./ containers.centroids_cnt'
+        centroids .= containers.new_centroids[1] ./ containers.centroids_cnt[1]'
     else
         ranges = splitter(ncol, n_threads)
 

--- a/src/light_elkan.jl
+++ b/src/light_elkan.jl
@@ -30,17 +30,12 @@ Internal function for the creation of all necessary intermidiate structures.
 - `centroids_dist` - symmetric matrix k x k which holds weighted distances between centroids
 """
 function create_containers(alg::LightElkan, k, nrow, ncol, n_threads)
-    if n_threads == 1
-        new_centroids = Array{Float64, 2}(undef, nrow, k)
-        centroids_cnt = Vector{Int}(undef, k)
-    else
-        new_centroids = Vector{Array{Float64, 2}}(undef, n_threads)
-        centroids_cnt = Vector{Vector{Int}}(undef, n_threads)
+    new_centroids = Vector{Array{Float64, 2}}(undef, n_threads)
+    centroids_cnt = Vector{Vector{Int}}(undef, n_threads)
 
-        for i in 1:n_threads
-            new_centroids[i] = Array{Float64, 2}(undef, nrow, k)
-            centroids_cnt[i] = Vector{Int}(undef, k)
-        end
+    for i in 1:n_threads
+        new_centroids[i] = Array{Float64, 2}(undef, nrow, k)
+        centroids_cnt[i] = Vector{Int}(undef, k)
     end
 
     labels = zeros(Int, ncol)
@@ -103,13 +98,8 @@ function chunk_update_centroids!(centroids, containers, ::LightElkan,
     design_matrix, r, idx)
 
     # unpack containers for easier manipulations
-    if idx == 0
-        new_centroids = containers.new_centroids
-        centroids_cnt = containers.centroids_cnt
-    else
-        new_centroids = containers.new_centroids[idx]
-        centroids_cnt = containers.centroids_cnt[idx]
-    end
+    new_centroids = containers.new_centroids[idx]
+    centroids_cnt = containers.centroids_cnt[idx]
     centroids_dist = containers.centroids_dist
     labels = containers.labels
 

--- a/src/lloyd.jl
+++ b/src/lloyd.jl
@@ -22,17 +22,12 @@ Internal function for the creation of all necessary intermidiate structures.
 - `labels` - vector which holds labels of corresponding points
 """
 function create_containers(::Lloyd, k, nrow, ncol, n_threads)
-    if n_threads == 1
-        new_centroids = Array{Float64, 2}(undef, nrow, k)
-        centroids_cnt = Vector{Int}(undef, k)
-    else
-        new_centroids = Vector{Array{Float64, 2}}(undef, n_threads)
-        centroids_cnt = Vector{Vector{Int}}(undef, n_threads)
+    new_centroids = Vector{Array{Float64, 2}}(undef, n_threads)
+    centroids_cnt = Vector{Vector{Int}}(undef, n_threads)
 
-        for i in 1:n_threads
-            new_centroids[i] = Array{Float64, 2}(undef, nrow, k)
-            centroids_cnt[i] = Vector{Int}(undef, k)
-        end
+    for i in 1:n_threads
+        new_centroids[i] = Array{Float64, 2}(undef, nrow, k)
+        centroids_cnt[i] = Vector{Int}(undef, k)
     end
 
     labels = Vector{Int}(undef, ncol)
@@ -43,20 +38,12 @@ end
 
 update_containers!(containers, ::Lloyd, centroids, n_threads) = nothing
 
-"""
-    # TODO: Docs
-"""
 function chunk_update_centroids!(centroids, containers, ::Lloyd,
     design_matrix, r, idx)
 
     # unpack containers for easier manipulations
-    if idx == 0
-        new_centroids = containers.new_centroids
-        centroids_cnt = containers.centroids_cnt
-    else
-        new_centroids = containers.new_centroids[idx]
-        centroids_cnt = containers.centroids_cnt[idx]
-    end
+    new_centroids = containers.new_centroids[idx]
+    centroids_cnt = containers.centroids_cnt[idx]
     labels = containers.labels
 
     new_centroids .= 0.0


### PR DESCRIPTION
Fixed type instability, now it should work as fast as before.
Also exported `Lloyd` and `LightElkan`, so they can be used without `ParallelKMeans` prefix.