### PR TITLE
Simplify the instructions to get the experimental branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ pkg> add ParallelKMeans
 For the few (and selected) brave ones, one can simply grab the current experimental features by simply adding the experimental branch to your development environment after invoking the package manager with `]`:
 
 ```julia
-pkg> dev git@github.com:PyDataBlog/ParallelKMeans.jl.git
+pkg> add ParallelKMeans#experimental
 ```
 
-Don't forget to checkout the experimental branch and you are good to go with bleeding edge features and breaks!
+To revert to a stable version, you can simply run:
 
-```bash
-git checkout experimental
+```julia
+pkg> free ParallelKMeans
 ```
 
 _________________________________________________________________________________________________________


### PR DESCRIPTION
When you `dev` a package, if it isn't updated manually through `git`, it will stay on the commit you dev'ed it at.  

However, when adding a branch, Pkg automatically searches for the latest commit on that branch.  This simplifies the workflow when you only want a branch, without having to download the entire git repo.