### PR TITLE
Extend compat: StatsBase = "0.32, 0.33, 0.34"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.3'
+          version: '1.6'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.4
+          version: 1.6
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark Distances StatsBase BenchmarkTools BenchmarkCI@0.1"'
       - name: Run benchmarks

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 [compat]
 Distances = "0.8.2, 0.9, 0.10"
 MLJModelInterface = "^0.3,^0.4, 1.0"
-StatsBase = "0.32, 0.33"
+StatsBase = "0.32, 0.33, 0.34"
 UnsafeArrays = "1"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelKMeans"
 uuid = "42b8e9d4-006b-409a-8472-7f34b3fb58af"
 authors = ["Bernard Brenyah", "Andrey Oskin"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -15,7 +15,7 @@ Distances = "0.8.2, 0.9, 0.10"
 MLJModelInterface = "^0.3,^0.4, 1.0"
 StatsBase = "0.32, 0.33, 0.34"
 UnsafeArrays = "1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelKMeans"
 uuid = "42b8e9d4-006b-409a-8472-7f34b3fb58af"
 authors = ["Bernard Brenyah", "Andrey Oskin"]
-version = "1.0.2"
+version = "1.0.1"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelKMeans"
 uuid = "42b8e9d4-006b-409a-8472-7f34b3fb58af"
 authors = ["Bernard Brenyah", "Andrey Oskin"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"


### PR DESCRIPTION
@PyDataBlog 

**edit** This PR also dumps support for Julia < 1.6,  to get tests passing with minimal fuss. 